### PR TITLE
add missing ']' in the column-symbol way of selecting a column

### DIFF
--- a/Episode_7/DataFrames_and_Machine_Learning_Stuff.ipynb
+++ b/Episode_7/DataFrames_and_Machine_Learning_Stuff.ipynb
@@ -110,7 +110,7 @@
     "iris[!, \"SepalLength\"]\n",
     "\n",
     "# The colon-symbol way\n",
-    "iris[:, :SepalLength\n",
+    "iris[:, :SepalLength]\n",
     "\n",
     "# The bang-symbol way\n",
     "iris[!, :SepalLength]\n",


### PR DESCRIPTION
I noticed a small typo when watching episode #7 of the podcast. Your podcast has been a great tool for sharing Julia with friends. Thank you!